### PR TITLE
NODEの環境変数を設定する

### DIFF
--- a/api/.env.sample
+++ b/api/.env.sample
@@ -1,3 +1,4 @@
+NODE_ENV=development
 TZ=Asia/Tokyo
 
 # Environment variables declared in this file are automatically made available to Prisma.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,8 @@ FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN apt-get update -y && \ 
-  apt-get install -y openssl
+  apt-get install -y openssl && \
+  apt-get install -y vim
 RUN corepack enable
 
 # ビルド用イメージ

--- a/api/src/app.service.ts
+++ b/api/src/app.service.ts
@@ -9,6 +9,6 @@ export class AppService implements OnApplicationShutdown {
   }
 
   getHello(): string {
-    return 'Hello World!';
+    return `Hello World! env=${process.env.NODE_ENV}`;
   }
 }


### PR DESCRIPTION
## 概要
環境変数を設定し、dev,stg,prodなどの環境切り分けをできるようにする

## 修正内容
- 本番環境にvimをインストール
- 環境変数`NODE_ENV`を追加

## 備考
